### PR TITLE
chore(argocd): remove unnecessary url declaration

### DIFF
--- a/argocd/argocd.values.yml
+++ b/argocd/argocd.values.yml
@@ -7,7 +7,6 @@ configs:
   cm:
     application.instanceLabelKey: argocd.argoproj.io/instance
     kustomize.buildOptions: --enable-helm --load-restrictor=LoadRestrictionsNone
-    url: https://argocd.simulatan.me
     admin.enabled: "false"
     oidc.config: |
       name: Authelia


### PR DESCRIPTION
The Helm chart already sets it based on `global.domain`